### PR TITLE
Verarbeite Parameter für existierende Handles für Work und Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.json
 mets2handle.egg-info
 build
+venv

--- a/README.md
+++ b/README.md
@@ -6,10 +6,22 @@ Mets2Handle allows to create PIDs from XMLs
 
 ```
 pip install .
-python
+metstohandle -c <path_to_credentials> -o <output_mets.xml> <input_mets.xml>
 ```
 
-Using pyhton command line:
+If multiple DataObjects for the same Work and Version shall be
+registered, make sure that they all use the same handle for Work and
+Version. After registering the first DataObject, grab handles for Work
+and Version from the generated METS and pass them as parameters like
+this:
+
+```
+metstohandle -c <path_to_credentials> -v <version_pid> -w <work_pid> \
+    -o <output_mets.xml> <input_mets.xml>
+```
+
+Use this package as a library as follows:
+
 ```
 import mets2handle
 filename = <path_to_file>

--- a/mets2handle/metstohandle.py
+++ b/mets2handle/metstohandle.py
@@ -81,13 +81,11 @@ def m2h(filename,
     connection_details = {}
 
     print(Path.cwd())
-    try:
+    if True:
         with open(credentials, "r") as f:
             for line in f:
                 key, value = line.strip().split("|")
                 connection_details[key] = value
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        print('Please make sure that handle_connection.txt is in the same folder')
 
     header = {'accept': 'application/json', 'If-None-Match': 'default', 'If-Match': 'default',
               'Content-Type': 'application/json'}
@@ -168,10 +166,11 @@ def m2h(filename,
                                                            data=json.dumps(payload))
 
                 print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to create-Work-request')
+                response_from_handle_server.raise_for_status()
 
                 respon = json.loads(response_from_handle_server.text)
                 multiworkno = multiworkno + 1
-                if response_from_handle_server.status_code == 201:
+                if True: # Just to keep diff output short
                     # gets pid from response
                     pid = respon['handle']
                     cinematographic_work_pids.append(pid)
@@ -188,8 +187,6 @@ def m2h(filename,
 
                         baum = ET.ElementTree(root)
                         baum.write(metsfile, xml_declaration=True, encoding='utf-8')
-                else:
-                    print(response_from_handle_server.status_code, respon)
 
         # if the ID attribute of the dmdSec element is in the list of versions,
         #  generate a new UUID to use as the PID for the work, generate the JSON for the version,
@@ -225,8 +222,9 @@ def m2h(filename,
                                                            data=json.dumps(payload_version))
 
                 print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to create-Version-request')
+                response_from_handle_server.raise_for_status()
 
-                if response_from_handle_server.status_code == 201:
+                if True: # Just to keep diff output short
                     # gets pid from response
                     respon = json.loads(response_from_handle_server.text)
                     pid = respon['handle']
@@ -272,7 +270,8 @@ def m2h(filename,
                                                            data=json.dumps(payload))
 
                 print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to create-DataObject-request')
-                if response_from_handle_server.status_code == 201:
+                response_from_handle_server.raise_for_status()
+                if True: # Just to keep diff output short
                     respon = json.loads(response_from_handle_server.text)
                     pid = respon['handle']
                     dataobject_Pid = pid
@@ -303,6 +302,7 @@ def m2h(filename,
                 print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to update-Version-request')
 
                 print(response_from_handle_server)
+                response_from_handle_server.raise_for_status()
 
                 json.dump(mets2handle.buildData_Object_Json(dmdsec, ns, dataobject_Pid, version_pid),
                           open('dataobject.json', 'w', encoding='utf8'),
@@ -316,7 +316,8 @@ def m2h(filename,
                                                            data=json.dumps(payload))
 
                 print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to create-DataObject-request')
-                if response_from_handle_server.status_code == 201:
+                response_from_handle_server.raise_for_status()
+                if True: # Just to keep diff output short
                     respon = json.loads(response_from_handle_server.text)
                     pid = respon['handle']
 

--- a/mets2handle/metstohandle.py
+++ b/mets2handle/metstohandle.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright 2023, Stiftung Deutsche Kinemathek"
 __license__ = "GPL"
 __version__ = "3.0"
 
+import argparse
 import json
 import sys
 # import db_works_to_handle as xj
@@ -400,3 +401,35 @@ def m2h(filename,
                 print(response_from_handle_server)
                 response_from_handle_server.raise_for_status()
     return True  # if successfull
+
+
+def cli_entry_point():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-c', '--credentials', metavar='<credentials_file>',
+        default='handle_connection.txt',
+        help='File containing credentials for access to handle system'
+        ' (default: %(default)s).')
+    parser.add_argument(
+        '-d', '--dump-jsons', action='store_true',
+        help='Write generated json to stdout in, then send request.')
+    parser.add_argument(
+        '-o', '--out-file', metavar='<modified_mets>',
+        help='Do not modify METS in place but write to this file instead.')
+    parser.add_argument(
+        '-v', '--version-pid', metavar='<known_handle_for_version>',
+        help='Instead of registering new version handle, use this one.')
+    parser.add_argument(
+        '-w', '--work-pid', metavar='<known_handle_for_work>',
+        help='Instead of registering new work handle, use this one.')
+    parser.add_argument(
+        'mets_file', metavar='<mets_file>',
+        help='METS file containing dmdSecs for DataObject, Version, and Work.')
+    args = parser.parse_args()
+    return m2h(
+        args.mets_file,
+        out_file=args.out_file,
+        work_pid=args.work_pid,
+        version_pid=args.version_pid,
+        credentials=args.credentials,
+        dumpjsons=args.dump_jsons)

--- a/mets2handle/metstohandle.py
+++ b/mets2handle/metstohandle.py
@@ -290,20 +290,6 @@ def m2h(filename,
 
             if boolean_list_if_pids_exists[0] and boolean_list_if_pids_exists[1] and not boolean_list_if_pids_exists[
                 2]:  # case fresh dataobject in mets where version and work have a pid already
-
-                payload_version = mets2handle.buildVersionJson(root, ns, pid_works=cinematographic_work_pids,
-                                                               dataobject_pid=dataObjectPids, version_pid=version_pid)
-                print(payload_version)
-                print(version_uuid)
-                response_from_handle_server = requests.put(connection_details['url'] + version_uuid, auth=(
-                    connection_details['user'], connection_details['password']), headers=header,
-                                                           data=json.dumps(payload_version))
-
-                print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to update-Version-request')
-
-                print(response_from_handle_server)
-                response_from_handle_server.raise_for_status()
-
                 json.dump(mets2handle.buildData_Object_Json(dmdsec, ns, dataobject_Pid, version_pid),
                           open('dataobject.json', 'w', encoding='utf8'),
                           indent=4, sort_keys=False, ensure_ascii=False)
@@ -332,4 +318,17 @@ def m2h(filename,
                     with open(out_file, 'wb') as metsfile:
                         baum = ET.ElementTree(root)
                         baum.write(metsfile, xml_declaration=True, encoding='utf-8')
+
+                payload_version = mets2handle.buildVersionJson(root, ns, pid_works=cinematographic_work_pids,
+                                                               dataobject_pid=dataObjectPids, version_pid=version_pid)
+                print(payload_version)
+                print(version_uuid)
+                response_from_handle_server = requests.put(connection_details['url'] + version_uuid, auth=(
+                    connection_details['user'], connection_details['password']), headers=header,
+                                                           data=json.dumps(payload_version))
+
+                print(response_from_handle_server.text, response_from_handle_server.status_code, 'Response to update-Version-request')
+
+                print(response_from_handle_server)
+                response_from_handle_server.raise_for_status()
     return True  # if successfull

--- a/mets2handle/metstohandle.py
+++ b/mets2handle/metstohandle.py
@@ -125,6 +125,12 @@ def m2h(filename,
 
         if element_type == 'dataObject':
             dataobjects.append(div.get('DMDID'))
+    if len(versions) != 1:
+        raise ValueError(
+            f"Unexpectedly found {len(versions)} versions in {filename}.")
+    if len(dataobjects) != 1:
+        raise ValueError(
+            f"Unexpectedly found {len(dataobjects)} DataObjects in {filename}.")
 
     # empty list to hold PIDs of cinematographic works
     cinematographic_work_pids = []

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,10 @@ setup(name='mets2handle',
         'urllib3==2.0.3',
         'uuid==1.30',
         'pycountry==22.3.5'
-        ]
+        ],
+      entry_points={
+          'console_scripts': [
+              'metstohandle=mets2handle.metstohandle:cli_entry_point',
+          ],
+      }
     )


### PR DESCRIPTION
Vereinfache das Registrieren mehrerer DataObjects zu derselben
Version. Das Vorgehen ist kurz in README.md beschrieben.

Die aktuelle Implementierung ist verwendet die übergebenen Parameter
„im guten Glauben“; das heißt, es wird nicht überprüft, ob ein als
work_pid übergebener Handle tatsächlich ein Werk referenziert. Für ein
Proof of Concept sollte das aber reichen.